### PR TITLE
Use bulleted lists for help command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,10 +90,10 @@ client.ws.on('INTERACTION_CREATE', async (interaction: APIChatInputApplicationCo
         respond({
             content: stripIndent`
                 Slashtags is a simple [slash command](<https://support.discord.com/hc/en-us/articles/1500000368501>) tag bot.
-                • Use /create to create a tag, /edit to edit a tag, and /delete to delete a tag.
-                • All created tags will show when a user types /, making them easy to discover.
-                • The Manage Server permission is required to manage tags.
-                • Due to Discord limits, you can create up to 100 Slashtags per server. Slash commands may not show in servers with over 50 bots.
+                * Use /create to create a tag, /edit to edit a tag, and /delete to delete a tag.
+                * All created tags will show when a user types /, making them easy to discover.
+                * The Manage Server permission is required to manage tags.
+                * Due to Discord limits, you can create up to 100 Slashtags per server. Slash commands may not show in servers with over 50 bots.
                 Created by [advaith](<https://advaith.io>) • [Add to your server](<https://discord.com/api/oauth2/authorize?client_id=790910161953882147&scope=bot+applications.commands>) • [Privacy Policy](<https://gist.github.com/advaith1/6fd1ad3ed1ad30304ba97528f5561935>)`
         })
 


### PR DESCRIPTION
The help command currently using a special character for bulleted lists. This is no longer the case and needed since Discord started supporting [bulleted lists](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline#h_01GY0ER08B6V1X2X9X6HT4HTGG) in it's markdown. 

This PR replaces the bullet character (•) with a asterisk (*) in order to use Discord's markdown in the help message. 